### PR TITLE
bump axios to 0.21.1, resolves Server-Side Request Forgery vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@types/base-64": "^0.1.3",
     "@virgilsecurity/crypto-types": "^1.0.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "base-64": "^0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
```axios  <0.21.1
Severity: high
Server-Side Request Forgery - https://npmjs.com/advisories/1594
No fix available
node_modules/axios
  @virgilsecurity/keyknox  *
  Depends on vulnerable versions of axios
  node_modules/@virgilsecurity/keyknox
    @virgilsecurity/e3kit-base  *
    Depends on vulnerable versions of @virgilsecurity/keyknox
    node_modules/@virgilsecurity/e3kit-base
      @virgilsecurity/e3kit-browser  *
      Depends on vulnerable versions of @virgilsecurity/e3kit-base
      node_modules/@virgilsecurity/e3kit-browser
  virgil-pythia  >=0.3.0-alpha.0
  Depends on vulnerable versions of axios
  node_modules/virgil-pythia
```