### PR TITLE
Axios Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@types/base-64": "^0.1.3",
     "@virgilsecurity/crypto-types": "^1.0.0",
-    "axios": "^0.21.1",
+    "axios": "^1.6.8",
     "base-64": "^0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Axios version is 3+ years old. Vulnerabilities have been found in previous Axios versions, please update to the latest one.